### PR TITLE
ボリュームスライダーをいい感じに

### DIFF
--- a/client/components/containers/player/VolumeSlider.vue
+++ b/client/components/containers/player/VolumeSlider.vue
@@ -49,7 +49,6 @@ const volumeButtonIcon = (volumePercent: number, isMuted: boolean): VolumeButton
   if (isMuted || volumePercent === 0) return 'mdi-volume-mute';
   if (volumePercent === 100) return 'mdi-volume-high';
 
-  console.log(volumePercent);
   const volumeIconList: Array<VolumeButtonIcon> = [
     'mdi-volume-low',
     'mdi-volume-medium',
@@ -62,7 +61,10 @@ const volumeButtonIcon = (volumePercent: number, isMuted: boolean): VolumeButton
 
 export default Vue.extend({
   data(): Data {
-    const volumePercent = 100;
+    // volumePercent と isMuted は localStorage で永続化されてる
+    const volumePercent = this.$state().playback.isMuted
+      ? 0
+      : this.$state().playback.volumePercent;
     const interval = 10;
     const debounceSetter = debounce((positionMs: number) => positionMs, interval);
 

--- a/client/components/containers/player/VolumeSlider.vue
+++ b/client/components/containers/player/VolumeSlider.vue
@@ -1,10 +1,13 @@
 <template>
-  <div :class="$style.VolumeSlider">
+  <div
+    :title="sliderTitle"
+    :class="$style.VolumeSlider"
+  >
     <v-btn
       icon
       :width="32"
       :height="32"
-      :title="volumeButtonTitle"
+      :title="buttonTitle"
       @click="onVolumeButtonClicked"
     >
       <v-icon
@@ -16,13 +19,13 @@
     </v-btn>
 
     <v-slider
-      :value="volumePercent"
       color="active-icon"
       thumb-color="white"
       hide-details
       dense
-      @change="onChange"
+      :value="volumePercent"
       @input="onInput"
+      @change="onChange"
     />
   </div>
 </template>
@@ -43,19 +46,16 @@ type Data = {
 type VolumeButtonIcon = 'mdi-volume-mute' | 'mdi-volume-low' | 'mdi-volume-medium' | 'mdi-volume-high' | 'mdi-volume-high'
 
 const volumeButtonIcon = (volumePercent: number, isMuted: boolean): VolumeButtonIcon => {
-  if (isMuted) return 'mdi-volume-mute';
+  if (isMuted || volumePercent === 0) return 'mdi-volume-mute';
+  if (volumePercent === 100) return 'mdi-volume-high';
 
+  console.log(volumePercent);
   const volumeIconList: Array<VolumeButtonIcon> = [
-    'mdi-volume-mute',
     'mdi-volume-low',
     'mdi-volume-medium',
     'mdi-volume-high',
-    'mdi-volume-high',
   ];
-  const index = Math.min(
-    Math.floor((volumePercent / 100) * volumeIconList.length),
-    volumeIconList.length - 1,
-  );
+  const index = Math.floor((volumePercent / 100) * volumeIconList.length);
 
   return volumeIconList[index];
 };
@@ -63,7 +63,7 @@ const volumeButtonIcon = (volumePercent: number, isMuted: boolean): VolumeButton
 export default Vue.extend({
   data(): Data {
     const volumePercent = 100;
-    const interval = 100;
+    const interval = 10;
     const debounceSetter = debounce((positionMs: number) => positionMs, interval);
 
     return {
@@ -78,10 +78,15 @@ export default Vue.extend({
     isMuted(): RootState['playback']['isMuted'] {
       return this.$state().playback.isMuted;
     },
-    volumeButtonTitle(): string {
+    buttonTitle(): string {
       return this.isMuted
         ? 'ミュートを解除'
         : 'ミュート';
+    },
+    sliderTitle(): string {
+      return this.isMuted
+        ? 'ミュート中'
+        : `ボリューム ${this.volumePercent}%`;
     },
     volumeButtonColor(): string | undefined {
       return this.isMuted

--- a/client/plugins/vuex-persist.ts
+++ b/client/plugins/vuex-persist.ts
@@ -3,9 +3,13 @@ import { Context } from '@nuxt/types';
 import { RootState } from 'typed-vuex';
 
 export default ({ store }: Context) => {
-  window.onNuxtReady(() => {
-    new VuexPersistence<RootState>({
-      modules: [],
-    }).plugin(store);
-  });
+  new VuexPersistence<RootState>({
+    storage: window.localStorage,
+    reducer: (state) => ({
+      playback: {
+        volumePercent: state.playback.volumePercent,
+        isMuted: state.playback.isMuted,
+      },
+    }),
+  }).plugin(store);
 };

--- a/client/store/playback/actions.ts
+++ b/client/store/playback/actions.ts
@@ -134,15 +134,16 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     const { devices } = await this.$spotify.player.getActiveDeviceList();
     const deviceList = devices ?? [];
     const activeDevice = deviceList.find((device) => device.is_active);
-    const volumePercent = activeDevice != null
-      ? activeDevice.volume_percent
-      : 100;
 
     commit('SET_DEVICE_LIST', deviceList);
-    commit('SET_VOLUME_PERCENT', { volumePercent });
 
-    if (activeDevice?.id != null) {
-      commit('SET_ACTIVE_DEVICE_ID', activeDevice.id);
+    if (activeDevice != null) {
+      // activeDevice がなく、このデバイスで再生する場合は localStorage で永続化されてる volumePercent が採用される
+      commit('SET_VOLUME_PERCENT', { volumePercent: activeDevice.volume_percent });
+
+      if (activeDevice.id != null) {
+        commit('SET_ACTIVE_DEVICE_ID', activeDevice.id);
+      }
     }
   },
 
@@ -657,7 +658,6 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     commit('SET_IS_SHUFFLED', false);
     commit('SET_REPEAT_MODE', 0);
     commit('SET_DISALLOWS', {});
-    commit('SET_VOLUME_PERCENT', { volumePercent: 0 });
     commit('SET_IS_MUTED', false);
   },
 };

--- a/client/store/playback/state.ts
+++ b/client/store/playback/state.ts
@@ -60,7 +60,7 @@ const state = (): PlaybackState => ({
   isShuffled: false,
   repeatMode: undefined,
   disallows: {},
-  volumePercent: 0,
+  volumePercent: 100,
   isMuted: false,
 });
 

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -70,8 +70,14 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
       // player が登録されていないときのみ初期化
       if (getters.isPlayerConnected || window.Spotify == null) return;
 
+      // volumePercent と isMuted は localStorage で永続化されてる
+      const volume = this.$state().playback.isMuted
+        ? 0
+        : this.$state().playback.volumePercent / 100;
       const player = new Spotify.Player({
         name: APP_NAME,
+        // 0 ~ 1 で指定
+        volume,
         // アクセストークンの更新が必要になったら呼ばれる
         getOAuthToken: async (callback) => {
           const {


### PR DESCRIPTION
## Done

- close #406
- 現在のボリュームの％をツールチップで表示
- `isMuted` と `volumePercent` は localStorage で永続化
- アイコンの表示を修正