### PR TITLE
プレイヤーのエラーハンドリング

### DIFF
--- a/client/observable/toast.ts
+++ b/client/observable/toast.ts
@@ -15,6 +15,7 @@ type ToastState = {
 export type $Toast = {
   toasts: Toast[]
   push: (toast: Toast) => void
+  set: (toast: Toast) => void
 }
 
 const state = Vue.observable<ToastState>({
@@ -31,5 +32,14 @@ export const $toast: $Toast = {
 
   push(toast: Toast) {
     state.toasts.push(toast);
+  },
+
+  // 同じメッセージがなければセットする
+  set(toast: Toast) {
+    const includedToast = state.toasts
+      .find(({ message, color }) => toast.message === message && toast.color === color);
+    if (includedToast == null) {
+      state.toasts.push(toast);
+    }
   },
 };

--- a/client/plugins/axios.ts
+++ b/client/plugins/axios.ts
@@ -30,9 +30,14 @@ const plugin: Plugin = ({ $axios, app }, inject) => {
     if (err.response?.status === 401) {
       // 認可リクエストによるエラーだった場合はアクセストークンを更新
       app.$dispatch('auth/refreshAccessToken');
-    } else if (err.message === 'Network Error') {
+    } else if (err.message.includes('Network Error')) {
       // ネットワークエラーだった場合は polling を中止
       app.$commit('playback/SET_POLLING_PLAYBACK_TIMER', undefined);
+      app.$toast.set({
+        color: 'error',
+        message: 'ネットワークエラーが発生しました。接続を確認してください。',
+        timeout: 1000 * 30,
+      });
     }
 
     throw new Error(err.message);

--- a/client/plugins/axios.ts
+++ b/client/plugins/axios.ts
@@ -27,9 +27,12 @@ const plugin: Plugin = ({ $axios, app }, inject) => {
   });
 
   spotifyApi.onResponseError((err) => {
-    // 認可リクエストによるエラーだった場合はアクセストークンを更新
     if (err.response?.status === 401) {
+      // 認可リクエストによるエラーだった場合はアクセストークンを更新
       app.$dispatch('auth/refreshAccessToken');
+    } else if (err.message === 'Network Error') {
+      // ネットワークエラーだった場合は polling を中止
+      app.$commit('playback/SET_POLLING_PLAYBACK_TIMER', undefined);
     }
 
     throw new Error(err.message);

--- a/client/store/auth/getters.ts
+++ b/client/store/auth/getters.ts
@@ -5,8 +5,9 @@ import { AuthState } from './state';
 import { SpotifyAPI } from '~~/types';
 
 export type AuthGetters = {
-  isLoggedin: boolean | undefined
+  isLoggedin: boolean
   isTokenExpired: () => boolean
+  finishedRefreshingToken: Promise<true>
   userId: string | undefined
   userDisplayName: string | undefined
   userAvatarSrc: (avatarSize?: number) => string| undefined
@@ -16,6 +17,7 @@ export type AuthGetters = {
 export type RootGetters = {
   'auth/isLoggedin': AuthGetters['isLoggedin']
   'auth/isTokenExpired': AuthGetters['isTokenExpired']
+  'auth/finishedRefreshingToken': AuthGetters['finishedRefreshingToken']
   'auth/userId': AuthGetters['userId']
   'auth/userDisplayName': AuthGetters['userDisplayName']
   'auth/userAvatarSrc': AuthGetters['userAvatarSrc']
@@ -32,6 +34,12 @@ const getters: Getters<AuthState, AuthGetters> = {
     return () => (state.expirationMs != null
       ? Date.now() > state.expirationMs
       : false);
+  },
+
+  finishedRefreshingToken(state) {
+    return state.isRefreshing
+      ? new Promise(() => {})
+      : Promise.resolve(true);
   },
 
   userId(state) {

--- a/client/store/auth/mutations.ts
+++ b/client/store/auth/mutations.ts
@@ -4,15 +4,17 @@ import { AuthState } from './state';
 import { SpotifyAPI } from '~~/types';
 
 export type AuthMutations = {
-  SET_ACCESS_TOKEN: SpotifyAPI.Auth.Token['access_token'] | undefined,
+  SET_ACCESS_TOKEN: SpotifyAPI.Auth.Token['access_token'] | undefined
   SET_EXPIRATION_MS: number | undefined
   SET_USER_DATA: SpotifyAPI.UserData |undefined
+  SET_IS_REFRESHING: boolean
 }
 
 export type RootMutations = {
   'auth/SET_ACCESS_TOKEN': AuthMutations['SET_ACCESS_TOKEN']
   'auth/SET_EXPIRATION_MS': AuthMutations['SET_EXPIRATION_MS']
   'auth/SET_USER_DATA': AuthMutations['SET_USER_DATA']
+  'auth/SET_IS_REFRESHING': AuthMutations['SET_IS_REFRESHING']
 }
 
 const mutations: Mutations<AuthState, AuthMutations> = {
@@ -28,6 +30,10 @@ const mutations: Mutations<AuthState, AuthMutations> = {
 
   SET_USER_DATA(state, userData): void {
     state.userData = userData;
+  },
+
+  SET_IS_REFRESHING(state, isRefreshing) {
+    state.isRefreshing = isRefreshing;
   },
 };
 

--- a/client/store/auth/state.ts
+++ b/client/store/auth/state.ts
@@ -4,12 +4,14 @@ export type AuthState = {
   accessToken: string | undefined;
   expirationMs: number | undefined
   userData: SpotifyAPI.UserData | undefined;
+  isRefreshing: boolean;
 }
 
 const state = (): AuthState => ({
   accessToken: undefined,
   expirationMs: undefined,
   userData: undefined,
+  isRefreshing: false,
 });
 
 export default state;

--- a/client/store/playback/actions.ts
+++ b/client/store/playback/actions.ts
@@ -370,7 +370,12 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     dispatch,
   }, payload?) {
     if (getters.isDisallowed('resuming') && payload == null) {
-      commit('SET_IS_PLAYING', true);
+      // @todo resuming が禁止されるのは再生中である場合に限らない (ネットワークエラーなど)
+      // commit('SET_IS_PLAYING', true);
+      this.$toast.push({
+        color: 'error',
+        message: 'トラックを再生できません',
+      });
       return;
     }
 
@@ -420,7 +425,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
         console.error({ err });
         this.$toast.push({
           color: 'error',
-          message: 'エラーが発生し、再生できません。',
+          message: 'エラーが発生し、トラックを再生できません。',
         });
 
         dispatch('pollCurrentPlayback', 0);
@@ -430,7 +435,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
         console.error({ err });
         this.$toast.push({
           color: 'error',
-          message: 'エラーが発生し、再生できません。',
+          message: 'エラーが発生し、トラックを再生できません。',
         });
 
         dispatch('pollCurrentPlayback', 0);
@@ -455,7 +460,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
       .catch((err: Error) => {
         console.error({ err });
         this.$toast.push({
-          color: 'warning',
+          color: 'error',
           message: 'エラーが発生しました。',
         });
 
@@ -543,6 +548,9 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
       });
   },
 
+  /**
+   * シャッフルのモードを変更
+   */
   async shuffle({
     state,
     getters,
@@ -563,8 +571,8 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
       }).catch((err: Error) => {
         console.error({ err });
         this.$toast.push({
-          color: 'warning',
-          message: 'エラーが発生し、シャッフルの状態を変更できませんでした。',
+          color: 'error',
+          message: 'エラーが発生し、シャッフルのモードを変更できませんでした。',
         });
       })
       .finally(() => {
@@ -575,7 +583,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
   },
 
   /**
-   * リピートの状態を変更
+   * リピートのモードを変更
    */
   async repeat({
     state,
@@ -600,8 +608,8 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
       .catch((err: Error) => {
         console.error({ err });
         this.$toast.push({
-          color: 'warning',
-          message: 'エラーが発生し、シャッフルの状態を変更できませんでした。',
+          color: 'error',
+          message: 'エラーが発生し、リピートのモードを変更できませんでした。',
         });
       })
       .finally(() => {

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -148,6 +148,16 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
         });
       });
 
+      // ネットワークのエラーなどで、トラックが再生できないとき
+      player.addListener('playback_error', (err) => {
+        console.error({ err });
+        this.$commit('playback/SET_IS_PLAYING', false);
+        this.$toast.push({
+          color: 'error',
+          message: 'トラックを再生できません',
+        });
+      });
+
       // 認証エラーが発生した場合
       player.addListener('authentication_error', async (err) => {
         console.error({ err });

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -96,7 +96,6 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
             expirationMs,
           } = this.$state().auth;
           const isExpired = this.$getters()['auth/isTokenExpired']();
-          console.info(isExpired, currentAccessToken);
           // すでに保持しているアクセストークンが有効の場合はそれを使う
           if (currentAccessToken != null && !isExpired) {
             callback(currentAccessToken);
@@ -159,7 +158,6 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
       const errorList: Spotify.ErrorTypes[] = [
         'initialization_error',
         'account_error',
-        'playback_error',
       ];
       errorList.forEach((errorType) => {
         player.addListener(errorType, (err) => {
@@ -171,7 +169,7 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
       player.addListener('playback_error', (err) => {
         console.error({ err });
         this.$commit('playback/SET_IS_PLAYING', false);
-        this.$toast.push({
+        this.$toast.set({
           color: 'error',
           message: 'トラックを再生できません',
         });


### PR DESCRIPTION
## Done

- ネットワークエラーのときの処理
  - 再生できないように
  - メッセージ表示
- `refreshAccessToken` を同時に複数リクエストしないように
- プレイヤーの各エラー発生時のメッセージ